### PR TITLE
export encoding is now utf-8

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -8,6 +8,7 @@ using System.Windows;
 using System.Xml;
 using XliffTranslatorTool.Parser;
 using System.Linq;
+using System.Text;
 
 namespace XliffTranslatorTool
 {
@@ -270,13 +271,18 @@ namespace XliffTranslatorTool
 
         private void WriteToFile(XmlDocument xmlDocument, string filePath)
         {
-            StringWriter stringWriter = new StringWriter();
-            xmlDocument.Save(stringWriter);
-            string indented = stringWriter.ToString().Replace("_AMP;_", "&").Replace("_LT;_", "<").Replace("_GT;_", ">");
-            using (StreamWriter streamWriter = new StreamWriter(filePath, false))
+            XmlWriterSettings settings = new XmlWriterSettings();
+            settings.Encoding = Encoding.GetEncoding("UTF-8");
+            settings.Indent = true;
+            using (XmlWriter writer = XmlWriter.Create(filePath, settings))
             {
-                streamWriter.Write(indented);
+                xmlDocument.Save(writer);
             }
+
+            string rawXML = File.ReadAllText(filePath);
+            string indented = rawXML.Replace("_AMP;_", "&").Replace("_LT;_", "<").Replace("_GT;_", ">");
+
+            File.WriteAllText(filePath, indented);
         }
 
         private static OpenFileDialog CreateOpenFileDialog()

--- a/Parser/XliffParser.cs
+++ b/Parser/XliffParser.cs
@@ -241,8 +241,6 @@ namespace XliffTranslatorTool.Parser
         public XmlDocument CreateXliffDocument(XliffVersion xliffVersion, IEnumerable translationUnitsCollection)
         {
             XmlDocument xmlDocument = new XmlDocument();
-            XmlNode docNode = xmlDocument.CreateXmlDeclaration("1.0", "UTF-8", null);
-            xmlDocument.AppendChild(docNode);
 
             switch (xliffVersion)
             {
@@ -257,7 +255,7 @@ namespace XliffTranslatorTool.Parser
 
         private XmlDocument CreateXliffDocumentV12(XmlDocument xmlDocument, IEnumerable translationUnits)
         {
-            XmlNode rootNode = xmlDocument.CreateElement(Constants.XML_NODE_ROOT);
+            XmlNode rootNode = xmlDocument.CreateElement(Constants.XML_NODE_ROOT, Constants.XLIFF_NAMESPACE_V12);
 
             XmlAttribute versionAttribute = xmlDocument.CreateAttribute(Constants.XML_ATTRIBUTE_VERSION);
             versionAttribute.Value = Constants.XLIFF_VERSION_V12;
@@ -267,7 +265,7 @@ namespace XliffTranslatorTool.Parser
             namespaceAttribute.Value = Constants.XLIFF_NAMESPACE_V12;
             rootNode.Attributes.Append(namespaceAttribute);
 
-            XmlNode fileNode = xmlDocument.CreateElement(Constants.XML_NODE_FILE);
+            XmlNode fileNode = xmlDocument.CreateElement(Constants.XML_NODE_FILE, Constants.XLIFF_NAMESPACE_V12);
 
             if (!String.IsNullOrEmpty(SourceLanguage))
             {
@@ -276,29 +274,29 @@ namespace XliffTranslatorTool.Parser
                 fileNode.Attributes.Append(sourceLanguageAttribute);
             }
 
-            XmlNode bodyNode = xmlDocument.CreateElement(Constants.XML_NODE_BODY_V12);
+            XmlNode bodyNode = xmlDocument.CreateElement(Constants.XML_NODE_BODY_V12, Constants.XLIFF_NAMESPACE_V12);
 
             foreach (TranslationUnit translationUnit in translationUnits)
             {
                 if (String.IsNullOrEmpty(translationUnit.Identifier)) continue;
 
-                XmlNode translationUnitNode = xmlDocument.CreateElement(Constants.XML_NODE_TRANSLATION_UNIT_V12);
+                XmlNode translationUnitNode = xmlDocument.CreateElement(Constants.XML_NODE_TRANSLATION_UNIT_V12, Constants.XLIFF_NAMESPACE_V12);
 
                 XmlAttribute identifierAttribute = xmlDocument.CreateAttribute(Constants.XML_ATTRIBUTE_IDENTIFIER);
                 identifierAttribute.Value = translationUnit.Identifier;
                 translationUnitNode.Attributes.Append(identifierAttribute);
 
-                XmlNode sourceNode = xmlDocument.CreateElement(Constants.XML_NODE_SOURCE);
+                XmlNode sourceNode = xmlDocument.CreateElement(Constants.XML_NODE_SOURCE, Constants.XLIFF_NAMESPACE_V12);
                 sourceNode.InnerText = translationUnit.Source;
                 translationUnitNode.AppendChild(sourceNode);
 
-                XmlNode targetNode = xmlDocument.CreateElement(Constants.XML_NODE_TARGET);
+                XmlNode targetNode = xmlDocument.CreateElement(Constants.XML_NODE_TARGET, Constants.XLIFF_NAMESPACE_V12);
                 targetNode.InnerText = translationUnit.Target;
                 translationUnitNode.AppendChild(targetNode);
 
                 if (!String.IsNullOrEmpty(translationUnit.Description))
                 {
-                    XmlNode descriptionNode = xmlDocument.CreateElement(Constants.XML_NODE_NOTE);
+                    XmlNode descriptionNode = xmlDocument.CreateElement(Constants.XML_NODE_NOTE, Constants.XLIFF_NAMESPACE_V12);
 
                     XmlAttribute fromAttribute = xmlDocument.CreateAttribute(Constants.XML_ATTRIBUTE_EXTRA_DATA_V12);
                     fromAttribute.Value = Constants.XML_ATTRIBUTE_VALUE_DESCRIPTION;
@@ -309,7 +307,7 @@ namespace XliffTranslatorTool.Parser
 
                 if (!String.IsNullOrEmpty(translationUnit.Meaning))
                 {
-                    XmlNode meaningNode = xmlDocument.CreateElement(Constants.XML_NODE_NOTE);
+                    XmlNode meaningNode = xmlDocument.CreateElement(Constants.XML_NODE_NOTE, Constants.XLIFF_NAMESPACE_V12);
 
                     XmlAttribute fromAttribute = xmlDocument.CreateAttribute(Constants.XML_ATTRIBUTE_EXTRA_DATA_V12);
                     fromAttribute.Value = Constants.XML_ATTRIBUTE_VALUE_MEANING;
@@ -330,7 +328,7 @@ namespace XliffTranslatorTool.Parser
 
         private XmlDocument CreateXliffDocumentV20(XmlDocument xmlDocument, IEnumerable translationUnits)
         {
-            XmlNode rootNode = xmlDocument.CreateElement(Constants.XML_NODE_ROOT);
+            XmlNode rootNode = xmlDocument.CreateElement(Constants.XML_NODE_ROOT, Constants.XLIFF_NAMESPACE_V20);
 
             XmlAttribute versionAttribute = xmlDocument.CreateAttribute(Constants.XML_ATTRIBUTE_VERSION);
             versionAttribute.Value = Constants.XLIFF_VERSION_V20;
@@ -347,25 +345,25 @@ namespace XliffTranslatorTool.Parser
                 rootNode.Attributes.Append(sourceLanguageAttribute);
             }
 
-            XmlNode fileNode = xmlDocument.CreateElement(Constants.XML_NODE_FILE);
+            XmlNode fileNode = xmlDocument.CreateElement(Constants.XML_NODE_FILE, Constants.XLIFF_NAMESPACE_V20);
 
             foreach (TranslationUnit translationUnit in translationUnits)
             {
                 if (String.IsNullOrEmpty(translationUnit.Identifier)) continue;
 
-                XmlNode translationUnitNode = xmlDocument.CreateElement(Constants.XML_NODE_TRANSLATION_UNIT_V20);
+                XmlNode translationUnitNode = xmlDocument.CreateElement(Constants.XML_NODE_TRANSLATION_UNIT_V20, Constants.XLIFF_NAMESPACE_V20);
 
                 XmlAttribute identifierAttribute = xmlDocument.CreateAttribute(Constants.XML_ATTRIBUTE_IDENTIFIER);
                 identifierAttribute.Value = translationUnit.Identifier;
                 translationUnitNode.Attributes.Append(identifierAttribute);
 
-                XmlNode segmentNode = xmlDocument.CreateElement(Constants.XML_NODE_SEGMENT_V20);
+                XmlNode segmentNode = xmlDocument.CreateElement(Constants.XML_NODE_SEGMENT_V20, Constants.XLIFF_NAMESPACE_V20);
 
-                XmlNode sourceNode = xmlDocument.CreateElement(Constants.XML_NODE_SOURCE);
+                XmlNode sourceNode = xmlDocument.CreateElement(Constants.XML_NODE_SOURCE, Constants.XLIFF_NAMESPACE_V20);
                 sourceNode.InnerText = translationUnit.Source;
                 segmentNode.AppendChild(sourceNode);
 
-                XmlNode targetNode = xmlDocument.CreateElement(Constants.XML_NODE_TARGET);
+                XmlNode targetNode = xmlDocument.CreateElement(Constants.XML_NODE_TARGET, Constants.XLIFF_NAMESPACE_V20);
                 targetNode.InnerText = translationUnit.Target;
                 segmentNode.AppendChild(targetNode);
                 translationUnitNode.AppendChild(segmentNode);
@@ -374,11 +372,11 @@ namespace XliffTranslatorTool.Parser
                 bool isMeaningNullOrEmpty = String.IsNullOrEmpty(translationUnit.Meaning);
                 if (!isDescriptionNullOrEmpty || !isMeaningNullOrEmpty)
                 {
-                    XmlNode notesNode = xmlDocument.CreateElement(Constants.XML_NODE_NOTES_V20);
+                    XmlNode notesNode = xmlDocument.CreateElement(Constants.XML_NODE_NOTES_V20, Constants.XLIFF_NAMESPACE_V20);
 
                     if (!isDescriptionNullOrEmpty)
                     {
-                        XmlNode descriptionNode = xmlDocument.CreateElement(Constants.XML_NODE_NOTE);
+                        XmlNode descriptionNode = xmlDocument.CreateElement(Constants.XML_NODE_NOTE, Constants.XLIFF_NAMESPACE_V20);
 
                         XmlAttribute categoryAttribute = xmlDocument.CreateAttribute(Constants.XML_ATTRIBUTE_EXTRA_DATA_V20);
                         categoryAttribute.Value = Constants.XML_ATTRIBUTE_VALUE_DESCRIPTION;
@@ -389,7 +387,7 @@ namespace XliffTranslatorTool.Parser
 
                     if (!isMeaningNullOrEmpty)
                     {
-                        XmlNode meaningNode = xmlDocument.CreateElement(Constants.XML_NODE_NOTE);
+                        XmlNode meaningNode = xmlDocument.CreateElement(Constants.XML_NODE_NOTE, Constants.XLIFF_NAMESPACE_V20);
 
                         XmlAttribute categoryAttribute = xmlDocument.CreateAttribute(Constants.XML_ATTRIBUTE_EXTRA_DATA_V20);
                         categoryAttribute.Value = Constants.XML_ATTRIBUTE_VALUE_MEANING;


### PR DESCRIPTION
This fix will set the export encoding to UTF-8. 

(The namespace indication in CreateElement() calls is neccessary for the XmlWriter.)